### PR TITLE
Update Growth plan pricing features and improve layout

### DIFF
--- a/src/components/ModernShowcase.jsx
+++ b/src/components/ModernShowcase.jsx
@@ -719,7 +719,12 @@ const ModernShowcase = ({ currency, showPricing: initialShowPricing }) => {
         },
         {
           name: 'Multi-Channel Ad Management',
-          tooltip: `We strategically test and optimise up to 2 channels. Initial ad spend included with your plan, plus you can add up to ${selectedCurrency === 'USD' ? '$6,350' : selectedCurrency === 'EUR' ? '€5,850' : '£5,000'} per month for expanded reach.`,
+          tooltip: `We'll strategically test and optimise up to 2 channels (email + paid ads). Your plan includes initial ad spend, and you can boost this further with up to an additional ${selectedCurrency === 'USD' ? '$6,350' : selectedCurrency === 'EUR' ? '€5,850' : '£5,000'} extra ad spend per month.`,
+          included: true
+        },
+        {
+          name: `${selectedCurrency === 'USD' ? '$630' : selectedCurrency === 'EUR' ? '€580' : '£500'} LinkedIn/Meta Ad Spend/month`,
+          tooltip: `We will build and run LinkedIn or Meta ads with up to ${selectedCurrency === 'USD' ? '$630' : selectedCurrency === 'EUR' ? '€580' : '£500'} spend per month included`,
           included: true
         },
         {


### PR DESCRIPTION
- Add £500/month LinkedIn/Meta ad spend (included) with currency conversion
- Update Multi-Channel tooltip to clarify email + paid ads strategy
- Fix Self Managed plan alignment by shortening first line item
- Reorder features: Multi-Channel Ad Management now above Managed Replies in all plans
- Improve visual hierarchy showing feature progression across tiers

🤖 Generated with [Claude Code](https://claude.ai/code)